### PR TITLE
Soloing should be handled independently across parts

### DIFF
--- a/loopers-common/src/gui_channel.rs
+++ b/loopers-common/src/gui_channel.rs
@@ -24,6 +24,7 @@ pub struct EngineStateSnapshot {
     pub active_looper: u32,
     pub looper_count: usize,
     pub part: Part,
+    pub solo: bool,
     pub sync_mode: QuantizationMode,
     pub input_levels: [u8; 2],
     pub looper_levels: [[u8; 2]; 64],

--- a/loopers-common/src/music.rs
+++ b/loopers-common/src/music.rs
@@ -83,12 +83,10 @@ mod tests {
 
         assert!(
             next_beat_time.0 <= time + frames as i64,
-            format!(
-                "{} > {} (time = {})",
-                next_beat_time.0,
-                time + frames as i64,
-                time
-            )
+            "{} > {} (time = {})",
+            next_beat_time.0,
+            time + frames as i64,
+            time
         );
 
         // test that we never suggest beats in the past

--- a/loopers-gui/src/lib.rs
+++ b/loopers-gui/src/lib.rs
@@ -73,11 +73,7 @@ pub struct LooperData {
 
 impl LooperData {
     fn mode_with_solo(&self, data: &AppData) -> LooperMode {
-        let solo = data
-            .loopers
-            .iter()
-            .any(|(_, l)| l.mode == LooperMode::Soloed);
-        if solo && self.mode != LooperMode::Soloed {
+        if data.engine_state.solo && self.mode != LooperMode::Soloed {
             LooperMode::Muted
         } else {
             self.mode
@@ -183,6 +179,7 @@ impl Gui {
                     active_looper: 0,
                     looper_count: 0,
                     part: Part::A,
+                    solo: false,
                     sync_mode: QuantizationMode::Measure,
                     input_levels: [0, 0],
                     looper_levels: [[0; 2]; 64],


### PR DESCRIPTION
This PR causes soloing to be isolated within a part; i.e., if looper 1 in part A is soloed, and we switch to part B which has no solo loopers, all loopers should play in part B.