### PR TITLE
Added Dockerfile.aarch64 and build file to build for Raspberry Pi

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,20 @@
+FROM rust:latest
+
+RUN apt update && apt upgrade -y
+RUN apt install -y g++-aarch64-linux-gnu libc6-dev-arm64-cross
+RUN rustup target add aarch64-unknown-linux-gnu
+RUN rustup toolchain install stable-aarch64-unknown-linux-gnu
+RUN DEBIAN_FRONTEND='noninteractive' apt install -y jackd2:arm64 libjack-jackd2-dev:arm64 libgl1-mesa-dev:arm64 libsdl2-dev:arm64
+RUN DEBIAN_FRONTEND='noninteractive' apt install -y python2 python ninja-build
+RUN apt install -y clang:arm64
+
+WORKDIR /app
+
+ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
+    CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc \
+    CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++ \
+    SKIA_NINJA_COMMAND=/usr/bin/ninja \
+    CC=clang \
+    CXX=clang++
+
+CMD ["cargo", "build", "--target", "aarch64-unknown-linux-gnu", "--release"]

--- a/build-rasp-aarch64.sh
+++ b/build-rasp-aarch64.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build . -t rust_cross_compile/aarch64 -f Dockerfile.aarch64
+docker run --rm -ti -v `pwd`:/app rust_cross_compile/aarch64


### PR DESCRIPTION
Running ./build-rasp-aarch64.sh will build a release version of
loopers for the aarch64 (Raspbian 64-bit) architecture at
target/aarch64-unknown-linux-gnu/release/loopers that can be
scp'ed over to your Raspberry Pi, and chmod +x loopers and then
./loopers should execute it.