### PR TITLE
Fixed runtime error at GL context creation

### DIFF
--- a/loopers-gui/src/skia.rs
+++ b/loopers-gui/src/skia.rs
@@ -1,4 +1,4 @@
-use skia_safe::gpu::gl::FramebufferInfo;
+use skia_safe::gpu::gl::{FramebufferInfo, Interface};
 use skia_safe::gpu::{BackendRenderTarget, DirectContext, SurfaceOrigin};
 use skia_safe::{
     Color, ColorType, Font, Paint, PictureRecorder, Point, Rect, Size, Surface, TextBlob, Typeface,
@@ -87,7 +87,14 @@ pub fn skia_main(mut gui: Gui) {
 
     let debug = std::env::var("DEBUG").is_ok();
 
-    let mut gr_context = DirectContext::new_gl(None, None).unwrap();
+    let interface = Interface::new_load_with(|name| {
+        if name == "eglGetCurrentDisplay" {
+            return std::ptr::null();
+        }
+        video_subsystem.gl_get_proc_address(&name) as *const _
+    });
+
+    let mut gr_context = DirectContext::new_gl(interface, None).unwrap();
 
     let mut fboid: GLint = 0;
     unsafe { gl::GetIntegerv(gl::FRAMEBUFFER_BINDING, &mut fboid) };


### PR DESCRIPTION
When running in Fedora 39, GUI initialization failed with the backtrace below.
This pull request fixes the issue by providing a valid `Interface` instead of `None` in `DirectContext::new_gl(...)`.

This solution is based on [an example from the rust-skia repository](https://github.com/rust-skia/rust-skia/blob/0100c986599f1a19f17805926a654780c6f3a38c/skia-safe/examples/gl-window/main.rs#L149).

```
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', loopers-gui/src/skia.rs:90:60
stack backtrace:
   0: rust_begin_unwind
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:593:5
   1: core::panicking::panic_fmt
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panicking.rs:67:14
   2: core::panicking::panic
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panicking.rs:117:5
   3: core::option::Option<T>::unwrap
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/option.rs:935:21
   4: loopers_gui::skia::skia_main
             at ./loopers-gui/src/skia.rs:90:26
   5: loopers_gui::Gui::start
             at ./loopers-gui/src/lib.rs:208:9
   6: loopers::loopers_jack::jack_main
             at ./loopers/src/loopers_jack.rs:314:9
   7: loopers::main
             at ./loopers/src/main.rs:139:13
   8: core::ops::function::FnOnce::call_once
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/ops/function.rs:250:5
```
